### PR TITLE
Add out_dir and shift_dir to DUT

### DIFF
--- a/filelist.f
+++ b/filelist.f
@@ -20,6 +20,7 @@ src/sim/tb_top.sv
 src/sim/objects/seq_item.sv
 src/sim/objects/rsp_item.sv
 src/sim/objects/seq.sv
+src/sim/objects/seq_fl.sv
 
 #------------------------------
 # Components

--- a/src/rtl/sipo_reg.sv
+++ b/src/rtl/sipo_reg.sv
@@ -73,7 +73,7 @@ module sipo_reg #(
     end
 
 
-    function logic [DATA_WIDTH-1:0] reverse_bits(input logic [DATA_WIDTH-1:0] in);
+    function automatic logic [DATA_WIDTH-1:0] reverse_bits(input logic [DATA_WIDTH-1:0] in);
         logic [DATA_WIDTH-1:0] reversed;
         integer i;
         begin

--- a/src/rtl/sipo_reg.sv
+++ b/src/rtl/sipo_reg.sv
@@ -1,29 +1,88 @@
+// module sipo_reg #(
+//     parameter int SHIFT_LEFT = 1,
+//     parameter int DATA_WIDTH = 32
+// )(
+//     input logic clk,
+//     input logic arst_n,
+//     input logic serial_in,
+//     input logic we,
+//     output logic [DATA_WIDTH-1:0] parallel_out
+// );
+//     logic [DATA_WIDTH-1:0] shift_reg;
+
+//     always_ff @(posedge clk or negedge arst_n) begin
+//         if (~arst_n) begin
+//             shift_reg <= {DATA_WIDTH{1'b0}};
+//         end else if (we) begin
+//             if(SHIFT_LEFT) begin
+//                 shift_reg <= {shift_reg[DATA_WIDTH-2:0], serial_in};
+//             end else begin
+//                 shift_reg <= {serial_in, shift_reg[DATA_WIDTH-1:1]};
+//             end
+//         //     parallel_out <= '0;
+//         // end else begin
+//         //     parallel_out <= shift_reg;
+//         end
+//     end
+
+//     assign parallel_out = we? '0 : shift_reg;
+// endmodule
+
+
 module sipo_reg #(
-    parameter int SHIFT_LEFT = 1,
     parameter int DATA_WIDTH = 32
 )(
     input logic clk,
     input logic arst_n,
     input logic serial_in,
     input logic we,
+    input logic out_dir, // 0: LSB first, 1: MSB first
+    input logic shift_dir, // 0: Shift Right, 1: Shift Left
+
     output logic [DATA_WIDTH-1:0] parallel_out
 );
     logic [DATA_WIDTH-1:0] shift_reg;
 
+    // Shift left / shift right
     always_ff @(posedge clk or negedge arst_n) begin
         if (~arst_n) begin
             shift_reg <= {DATA_WIDTH{1'b0}};
         end else if (we) begin
-            if(SHIFT_LEFT) begin
+            if (shift_dir) begin // Shift left
                 shift_reg <= {shift_reg[DATA_WIDTH-2:0], serial_in};
-            end else begin
+            end else begin // Shift right
                 shift_reg <= {serial_in, shift_reg[DATA_WIDTH-1:1]};
             end
-        //     parallel_out <= '0;
-        // end else begin
-        //     parallel_out <= shift_reg;
         end
     end
 
-    assign parallel_out = we? '0 : shift_reg;
+    // Output normal or reverse order
+    always_ff @(posedge clk or negedge arst_n) begin
+        if (~arst_n) begin
+            parallel_out <= {DATA_WIDTH{1'b0}};
+        end else if (~we) begin
+            if (out_dir) begin // MSB to LSB (reverse order)
+                // Reverse the bits in shift_reg
+                parallel_out <= reverse_bits(shift_reg);
+            end else begin // LSB to MSB (normal order)
+                parallel_out <= shift_reg;
+            end
+        end else begin
+            parallel_out <= {DATA_WIDTH{1'b0}};
+        end
+    end
+
+
+    function logic [DATA_WIDTH-1:0] reverse_bits(input logic [DATA_WIDTH-1:0] in);
+        logic [DATA_WIDTH-1:0] reversed;
+        integer i;
+        begin
+            reversed = '0;
+            for (i = 0; i < DATA_WIDTH; i = i + 1) begin
+                reversed[i] = in[DATA_WIDTH-i-1];
+            end
+            reverse_bits = reversed;
+        end
+    endfunction
+
 endmodule

--- a/src/rtl/sipo_reg.sv
+++ b/src/rtl/sipo_reg.sv
@@ -55,22 +55,8 @@ module sipo_reg #(
             end
         end
     end
-
-    // Output normal or reverse order
-    always_ff @(posedge clk or negedge arst_n) begin
-        if (~arst_n) begin
-            parallel_out <= '0;
-        end else if (~load) begin
-            if (out_dir) begin // MSB to LSB (reverse order)
-                // Reverse the bits in shift_reg
-                parallel_out <= reverse_bits(shift_reg);
-            end else begin // LSB to MSB (normal order)
-                parallel_out <= shift_reg;
-            end
-        end else begin
-            parallel_out <= '0;
-        end
-    end
+    
+    assign parallel_out = load ? '0 : out_dir ? reverse_bits(shift_reg) : shift_reg;
 
 
     function automatic logic [DATA_WIDTH-1:0] reverse_bits(input logic [DATA_WIDTH-1:0] in);

--- a/src/rtl/sipo_reg.sv
+++ b/src/rtl/sipo_reg.sv
@@ -37,8 +37,6 @@ module sipo_reg #(
     input logic serial_in,
     input logic load,
     input logic out_dir, // 0: LSB first, 1: MSB first
-    input logic shift_dir, // 0: Shift Right, 1: Shift Left
-
     output logic [DATA_WIDTH-1:0] parallel_out
 );
     logic [DATA_WIDTH-1:0] shift_reg;
@@ -48,11 +46,7 @@ module sipo_reg #(
         if (~arst_n) begin
             shift_reg <= '0;
         end else if (load) begin
-            if (shift_dir) begin // Shift left
-                shift_reg <= {shift_reg[DATA_WIDTH-2:0], serial_in};
-            end else begin // Shift right
-                shift_reg <= {serial_in, shift_reg[DATA_WIDTH-1:1]};
-            end
+            shift_reg <= {shift_reg[DATA_WIDTH-2:0], serial_in};
         end
     end
     

--- a/src/rtl/sipo_reg.sv
+++ b/src/rtl/sipo_reg.sv
@@ -35,7 +35,7 @@ module sipo_reg #(
     input logic clk,
     input logic arst_n,
     input logic serial_in,
-    input logic we,
+    input logic load,
     input logic out_dir, // 0: LSB first, 1: MSB first
     input logic shift_dir, // 0: Shift Right, 1: Shift Left
 
@@ -46,8 +46,8 @@ module sipo_reg #(
     // Shift left / shift right
     always_ff @(posedge clk or negedge arst_n) begin
         if (~arst_n) begin
-            shift_reg <= {DATA_WIDTH{1'b0}};
-        end else if (we) begin
+            shift_reg <= '0;
+        end else if (load) begin
             if (shift_dir) begin // Shift left
                 shift_reg <= {shift_reg[DATA_WIDTH-2:0], serial_in};
             end else begin // Shift right
@@ -59,8 +59,8 @@ module sipo_reg #(
     // Output normal or reverse order
     always_ff @(posedge clk or negedge arst_n) begin
         if (~arst_n) begin
-            parallel_out <= {DATA_WIDTH{1'b0}};
-        end else if (~we) begin
+            parallel_out <= '0;
+        end else if (~load) begin
             if (out_dir) begin // MSB to LSB (reverse order)
                 // Reverse the bits in shift_reg
                 parallel_out <= reverse_bits(shift_reg);
@@ -68,7 +68,7 @@ module sipo_reg #(
                 parallel_out <= shift_reg;
             end
         end else begin
-            parallel_out <= {DATA_WIDTH{1'b0}};
+            parallel_out <= '0;
         end
     end
 

--- a/src/sim/components/driver.sv
+++ b/src/sim/components/driver.sv
@@ -31,8 +31,8 @@ class driver extends uvm_driver#(seq_item);
 
             seq_item_port.get_next_item(item);
 
-            `uvm_info(get_type_name(), $sformatf("Driving signals: serial_in=%0b, we=%0b", 
-                    item.serial_in, item.we), UVM_LOW)
+            `uvm_info(get_type_name(), $sformatf("Driving signals: serial_in=%0b, we=%0b, out_dir=%0b, shift_dir=%0b", 
+                    item.serial_in, item.we,item.out_dir,item.shift_dir), UVM_LOW)
 
             data_if.serial_in   <= item.serial_in;
             data_if.we          <= item.we;

--- a/src/sim/components/driver.sv
+++ b/src/sim/components/driver.sv
@@ -31,13 +31,12 @@ class driver extends uvm_driver#(seq_item);
 
             seq_item_port.get_next_item(item);
 
-            `uvm_info(get_type_name(), $sformatf("Driving signals: serial_in=%0b, load=%0b, out_dir=%0b, shift_dir=%0b", 
-                    item.serial_in, item.load, item.out_dir, item.shift_dir), UVM_LOW)
+            `uvm_info(get_type_name(), $sformatf("Driving signals: serial_in=%0b, load=%0b, out_dir=%0b", 
+                    item.serial_in, item.load, item.out_dir), UVM_LOW)
 
             data_if.serial_in   <= item.serial_in;
             data_if.load        <= item.load;
             data_if.out_dir     <= item.out_dir;
-            data_if.shift_dir   <= item.shift_dir;
 
             seq_item_port.item_done();
         end

--- a/src/sim/components/driver.sv
+++ b/src/sim/components/driver.sv
@@ -36,6 +36,8 @@ class driver extends uvm_driver#(seq_item);
 
             data_if.serial_in   <= item.serial_in;
             data_if.we          <= item.we;
+            data_if.out_dir     <= item.out_dir;
+            data_if.shift_dir   <= item.shift_dir;
 
             seq_item_port.item_done();
         end

--- a/src/sim/components/driver.sv
+++ b/src/sim/components/driver.sv
@@ -31,11 +31,11 @@ class driver extends uvm_driver#(seq_item);
 
             seq_item_port.get_next_item(item);
 
-            `uvm_info(get_type_name(), $sformatf("Driving signals: serial_in=%0b, we=%0b, out_dir=%0b, shift_dir=%0b", 
-                    item.serial_in, item.we,item.out_dir,item.shift_dir), UVM_LOW)
+            `uvm_info(get_type_name(), $sformatf("Driving signals: serial_in=%0b, load=%0b, out_dir=%0b, shift_dir=%0b", 
+                    item.serial_in, item.load, item.out_dir, item.shift_dir), UVM_LOW)
 
             data_if.serial_in   <= item.serial_in;
-            data_if.we          <= item.we;
+            data_if.load        <= item.load;
             data_if.out_dir     <= item.out_dir;
             data_if.shift_dir   <= item.shift_dir;
 

--- a/src/sim/components/env.sv
+++ b/src/sim/components/env.sv
@@ -19,7 +19,7 @@ class env extends uvm_env;
 
     function void connect_phase(uvm_phase phase);
         // No virtual sequencer
-        agt.mon.ap.connect(scbd.ap);
+        agt.mon.ap.connect(scbd.imp);
     endfunction
 
 endclass : env

--- a/src/sim/components/monitor.sv
+++ b/src/sim/components/monitor.sv
@@ -33,14 +33,15 @@ class monitor extends uvm_monitor;
                 item = rsp_item::type_id::create("item");
 
                 @(posedge data_if.clk);
-                if (data_if.arst_n == 1'b0) begin
-                    `uvm_info(get_type_name(), "In reset, waiting for reset de-assertion", UVM_MEDIUM)
-                    @(posedge data_if.arst_n);  // Wait for reset to end
-                end
+                // if (data_if.arst_n == 1'b0) begin
+                //     `uvm_info(get_type_name(), "In reset, waiting for reset de-assertion", UVM_MEDIUM)
+                //     @(posedge data_if.arst_n);  // Wait for reset to end
+                // end
 
                 item.serial_in    = data_if.serial_in;
                 item.load         = data_if.load;
                 item.out_dir      = data_if.out_dir;
+                item.arst_n       = data_if.arst_n;
                 item.parallel_out = data_if.parallel_out;
 
                 `uvm_info(get_type_name(), $sformatf("Monitoring signals: serial_in=%0b, load=%0b, out_dir=%0b, parallel_out=%0h",

--- a/src/sim/components/monitor.sv
+++ b/src/sim/components/monitor.sv
@@ -44,8 +44,8 @@ class monitor extends uvm_monitor;
                 item.shift_dir    = data_if.shift_dir;
                 item.parallel_out  = data_if.parallel_out;
 
-                `uvm_info(get_type_name(), $sformatf("Monitoring signals: serial_in=%0b, we=%0b, parallel_out=%0h",
-                    item.serial_in, item.we, item.parallel_out), UVM_LOW)
+                `uvm_info(get_type_name(), $sformatf("Monitoring signals: serial_in=%0b, we=%0b, out_dir=%0b, shift_dir=%0b, parallel_out=%0h",
+                    item.serial_in, item.we,item.out_dir,item.shift_dir, item.parallel_out), UVM_LOW)
                     
                 ap.write(item);
             end

--- a/src/sim/components/monitor.sv
+++ b/src/sim/components/monitor.sv
@@ -40,6 +40,8 @@ class monitor extends uvm_monitor;
 
                 item.serial_in    = data_if.serial_in;
                 item.we           = data_if.we;
+                item.out_dir      = data_if.out_dir;
+                item.shift_dir    = data_if.shift_dir;
                 item.parallel_out  = data_if.parallel_out;
 
                 `uvm_info(get_type_name(), $sformatf("Monitoring signals: serial_in=%0b, we=%0b, parallel_out=%0h",

--- a/src/sim/components/monitor.sv
+++ b/src/sim/components/monitor.sv
@@ -41,11 +41,10 @@ class monitor extends uvm_monitor;
                 item.serial_in    = data_if.serial_in;
                 item.load         = data_if.load;
                 item.out_dir      = data_if.out_dir;
-                item.shift_dir    = data_if.shift_dir;
                 item.parallel_out = data_if.parallel_out;
 
-                `uvm_info(get_type_name(), $sformatf("Monitoring signals: serial_in=%0b, load=%0b, out_dir=%0b, shift_dir=%0b, parallel_out=%0h",
-                    item.serial_in, item.load, item.out_dir, item.shift_dir, item.parallel_out), UVM_LOW)
+                `uvm_info(get_type_name(), $sformatf("Monitoring signals: serial_in=%0b, load=%0b, out_dir=%0b, parallel_out=%0h",
+                    item.serial_in, item.load, item.out_dir, item.parallel_out), UVM_LOW)
                     
                 ap.write(item);
             end

--- a/src/sim/components/monitor.sv
+++ b/src/sim/components/monitor.sv
@@ -39,13 +39,13 @@ class monitor extends uvm_monitor;
                 end
 
                 item.serial_in    = data_if.serial_in;
-                item.we           = data_if.we;
+                item.load         = data_if.load;
                 item.out_dir      = data_if.out_dir;
                 item.shift_dir    = data_if.shift_dir;
-                item.parallel_out  = data_if.parallel_out;
+                item.parallel_out = data_if.parallel_out;
 
-                `uvm_info(get_type_name(), $sformatf("Monitoring signals: serial_in=%0b, we=%0b, out_dir=%0b, shift_dir=%0b, parallel_out=%0h",
-                    item.serial_in, item.we,item.out_dir,item.shift_dir, item.parallel_out), UVM_LOW)
+                `uvm_info(get_type_name(), $sformatf("Monitoring signals: serial_in=%0b, load=%0b, out_dir=%0b, shift_dir=%0b, parallel_out=%0h",
+                    item.serial_in, item.load, item.out_dir, item.shift_dir, item.parallel_out), UVM_LOW)
                     
                 ap.write(item);
             end

--- a/src/sim/components/scb.sv
+++ b/src/sim/components/scb.sv
@@ -49,20 +49,21 @@ class scb extends uvm_component;
 
         // Compare DUT output with golden model
         if(t.parallel_out !== output_expected) begin
-            `uvm_error(get_type_name(),
-                $sformatf("Mismatch detected! DUT=0x%0h, GOLD=0x%0h, serial_in=%0b, we=%0b",
-                          t.parallel_out, output_expected, t.serial_in, t.we))
+            `uvm_error(get_type_name(), 
+                $sformatf("Mismatch detected! DUT=0x%0h, GOLD=0x%0h, serial_in=%0b, we=%0b, out_dir=%0b, shift_dir=%0b",
+                        t.parallel_out, output_expected, t.serial_in, t.we, t.out_dir, t.shift_dir))
             fail_count++;
         end else begin
-            `uvm_info(get_type_name(),
-                $sformatf("Match: DUT=0x%0h, GOLD=0x%0h", t.parallel_out, output_expected), UVM_LOW)
+            `uvm_info(get_type_name(), 
+                $sformatf("Match: DUT=0x%0h, GOLD=0x%0h, serial_in=%0b, we=%0b, out_dir=%0b, shift_dir=%0b", 
+                    t.parallel_out, output_expected, t.serial_in, t.we, t.out_dir, t.shift_dir), UVM_LOW)
             pass_count++;
         end
 
     endfunction
 
     // Utility function to reverse the golden model bits
-    function logic [DATA_WIDTH-1:0] reverse_bits(input logic [DATA_WIDTH-1:0] in);
+    function automatic logic [DATA_WIDTH-1:0] reverse_bits(input logic [DATA_WIDTH-1:0] in);
         logic [DATA_WIDTH-1:0] reversed;
         integer i;
         begin

--- a/src/sim/components/scb.sv
+++ b/src/sim/components/scb.sv
@@ -1,11 +1,10 @@
 class scb extends uvm_component;
     `uvm_component_utils(scb)
 
-    // Analysis port to receive monitored transactions
-    uvm_analysis_imp #(rsp_item, scb) ap;
+    // Port to receive monitored transactions
+    uvm_analysis_imp #(rsp_item, scb) imp;
 
     localparam DATA_WIDTH = 32;
-    localparam SHIFT_LEFT = 1; // 1 for left shift, 0 for right shift
 
     // Golden model storage
     bit [DATA_WIDTH-1:0] golden_shift_reg;
@@ -17,7 +16,7 @@ class scb extends uvm_component;
 
     function new(string name = "sipo_scoreboard", uvm_component parent = null);
         super.new(name, parent);
-        ap = new("ap", this);
+        imp = new("imp", this);
 
         golden_shift_reg = '0;
         output_expected = '0;
@@ -36,7 +35,7 @@ class scb extends uvm_component;
         // Shift the golden model according to DUT behavior
         if(t.we) begin
              // When we is high, output_expected is zero
-            if(SHIFT_LEFT) begin
+            if(t.shift_dir) begin
                 golden_shift_reg = {golden_shift_reg[DATA_WIDTH-2:0], t.serial_in};
                 output_expected = '0;
             end else begin
@@ -45,7 +44,7 @@ class scb extends uvm_component;
             end
         end else begin
             // When we is low, output_expected should match shift register
-            output_expected = golden_shift_reg; 
+            output_expected =  t.out_dir ? reverse_bits(golden_shift_reg) : golden_shift_reg; 
         end
 
         // Compare DUT output with golden model
@@ -60,6 +59,19 @@ class scb extends uvm_component;
             pass_count++;
         end
 
+    endfunction
+
+    // Utility function to reverse the golden model bits
+    function logic [DATA_WIDTH-1:0] reverse_bits(input logic [DATA_WIDTH-1:0] in);
+        logic [DATA_WIDTH-1:0] reversed;
+        integer i;
+        begin
+            reversed = '0;
+            for (i = 0; i < DATA_WIDTH; i = i + 1) begin
+                reversed[i] = in[DATA_WIDTH-i-1];
+            end
+            reverse_bits = reversed;
+        end
     endfunction
 
     // Report summary at the end of simulation

--- a/src/sim/components/scb.sv
+++ b/src/sim/components/scb.sv
@@ -18,8 +18,6 @@ class scb extends uvm_component;
         super.new(name, parent);
         imp = new("imp", this);
 
-        golden_shift_reg = '0;
-        output_expected = '0;
         pass_count = 0;
         fail_count = 0;
     endfunction
@@ -33,7 +31,7 @@ class scb extends uvm_component;
     function void write(rsp_item t);
 
         // Shift the golden model according to DUT behavior
-        if(t.we) begin
+        if(t.load) begin
              // When we is high, output_expected is zero
             if(t.shift_dir) begin
                 golden_shift_reg = {golden_shift_reg[DATA_WIDTH-2:0], t.serial_in};
@@ -50,13 +48,13 @@ class scb extends uvm_component;
         // Compare DUT output with golden model
         if(t.parallel_out !== output_expected) begin
             `uvm_error(get_type_name(), 
-                $sformatf("Mismatch detected! DUT=0x%0h, GOLD=0x%0h, serial_in=%0b, we=%0b, out_dir=%0b, shift_dir=%0b",
-                        t.parallel_out, output_expected, t.serial_in, t.we, t.out_dir, t.shift_dir))
+                $sformatf("Mismatch detected! DUT=0x%0h, GOLD=0x%0h, serial_in=%0b, load=%0b, out_dir=%0b, shift_dir=%0b",
+                        t.parallel_out, output_expected, t.serial_in, t.load, t.out_dir, t.shift_dir))
             fail_count++;
         end else begin
             `uvm_info(get_type_name(), 
-                $sformatf("Match: DUT=0x%0h, GOLD=0x%0h, serial_in=%0b, we=%0b, out_dir=%0b, shift_dir=%0b", 
-                    t.parallel_out, output_expected, t.serial_in, t.we, t.out_dir, t.shift_dir), UVM_LOW)
+                $sformatf("Match: DUT=0x%0h, GOLD=0x%0h, serial_in=%0b, load=%0b, out_dir=%0b, shift_dir=%0b", 
+                    t.parallel_out, output_expected, t.serial_in, t.load, t.out_dir, t.shift_dir), UVM_LOW)
             pass_count++;
         end
 

--- a/src/sim/components/scb.sv
+++ b/src/sim/components/scb.sv
@@ -29,10 +29,11 @@ class scb extends uvm_component;
 
     // Called when monitor writes a transaction
     function void write(rsp_item t);
-
         // Shift the golden model according to DUT behavior
-        if(t.load) begin
-             // When we is high, output_expected is zero            
+        if(~t.arst_n) begin
+            output_expected = '0;
+        end else if(t.load) begin
+            // When we is high, output_expected is zero            
             golden_shift_reg = {golden_shift_reg[DATA_WIDTH-2:0], t.serial_in};
             output_expected = '0;
         end else begin

--- a/src/sim/components/scb.sv
+++ b/src/sim/components/scb.sv
@@ -32,14 +32,9 @@ class scb extends uvm_component;
 
         // Shift the golden model according to DUT behavior
         if(t.load) begin
-             // When we is high, output_expected is zero
-            if(t.shift_dir) begin
-                golden_shift_reg = {golden_shift_reg[DATA_WIDTH-2:0], t.serial_in};
-                output_expected = '0;
-            end else begin
-                golden_shift_reg = {t.serial_in, golden_shift_reg[DATA_WIDTH-1:1]};
-                output_expected = '0;
-            end
+             // When we is high, output_expected is zero            
+            golden_shift_reg = {golden_shift_reg[DATA_WIDTH-2:0], t.serial_in};
+            output_expected = '0;
         end else begin
             // When we is low, output_expected should match shift register
             output_expected =  t.out_dir ? reverse_bits(golden_shift_reg) : golden_shift_reg; 
@@ -48,13 +43,13 @@ class scb extends uvm_component;
         // Compare DUT output with golden model
         if(t.parallel_out !== output_expected) begin
             `uvm_error(get_type_name(), 
-                $sformatf("Mismatch detected! DUT=0x%0h, GOLD=0x%0h, serial_in=%0b, load=%0b, out_dir=%0b, shift_dir=%0b",
-                        t.parallel_out, output_expected, t.serial_in, t.load, t.out_dir, t.shift_dir))
+                $sformatf("Mismatch detected! DUT=0x%0h, GOLD=0x%0h, serial_in=%0b, load=%0b, out_dir=%0b",
+                        t.parallel_out, output_expected, t.serial_in, t.load, t.out_dir))
             fail_count++;
         end else begin
             `uvm_info(get_type_name(), 
-                $sformatf("Match: DUT=0x%0h, GOLD=0x%0h, serial_in=%0b, load=%0b, out_dir=%0b, shift_dir=%0b", 
-                    t.parallel_out, output_expected, t.serial_in, t.load, t.out_dir, t.shift_dir), UVM_LOW)
+                $sformatf("Match: DUT=0x%0h, GOLD=0x%0h, serial_in=%0b, load=%0b, out_dir=%0b", 
+                    t.parallel_out, output_expected, t.serial_in, t.load, t.out_dir), UVM_LOW)
             pass_count++;
         end
 

--- a/src/sim/interfaces/data_intf.sv
+++ b/src/sim/interfaces/data_intf.sv
@@ -6,7 +6,7 @@ interface data_intf #(
 );
     
     logic serial_in;
-    logic we;
+    logic load;
     logic out_dir;
     logic shift_dir;
     logic [DATA_WIDTH-1:0] parallel_out;

--- a/src/sim/interfaces/data_intf.sv
+++ b/src/sim/interfaces/data_intf.sv
@@ -7,5 +7,7 @@ interface data_intf #(
     
     logic serial_in;
     logic we;
+    logic out_dir;
+    logic shift_dir;
     logic [DATA_WIDTH-1:0] parallel_out;
 endinterface : data_intf

--- a/src/sim/interfaces/data_intf.sv
+++ b/src/sim/interfaces/data_intf.sv
@@ -8,6 +8,5 @@ interface data_intf #(
     logic serial_in;
     logic load;
     logic out_dir;
-    logic shift_dir;
     logic [DATA_WIDTH-1:0] parallel_out;
 endinterface : data_intf

--- a/src/sim/objects/seq.sv
+++ b/src/sim/objects/seq.sv
@@ -1,7 +1,7 @@
 class seq extends uvm_sequence#(seq_item);
     `uvm_object_utils(seq)
 
-    int unsigned seq_length = 32;
+    // int unsigned seq_length = 32;
 
     function new(string name = "seq");
         super.new(name);
@@ -9,25 +9,25 @@ class seq extends uvm_sequence#(seq_item);
 
     task body();
         
-        void'(uvm_config_db #(int unsigned)::get(uvm_root::get(), 
-            "seq_length", "int", seq_length));
+        // void'(uvm_config_db #(int unsigned)::get(uvm_root::get(), 
+        //     "seq_length", "int", seq_length));
 
-        `uvm_info(get_type_name(), 
-            $sformatf("Creating %0d number of sequences.", seq_length), UVM_LOW)
+        // `uvm_info(get_type_name(), 
+        //     $sformatf("Creating %0d number of sequences.", seq_length), UVM_LOW)
 
-        for (int unsigned i = 0; i < seq_length; i++) begin
+        // for (int unsigned i = 0; i < seq_length; i++) begin
             seq_item item;
             item = seq_item::type_id::create("item");
 
             assert(item.randomize()) else 
                 `uvm_fatal(get_type_name(), "Failed to randomize sequence item.")
-
-            `uvm_info(get_type_name(), $sformatf("Sending sequence item %0d: serial_in=%0b, load=%0b, out_dir=%0b", 
-                    i, item.serial_in, item.load, item.out_dir), UVM_LOW)
+            
+            `uvm_info(get_type_name(), $sformatf("Sending sequence item: serial_in=%0b, load=%0b, out_dir=%0b", 
+                    item.serial_in, item.load, item.out_dir), UVM_LOW)
 
             start_item(item);
             finish_item(item);
-        end
+        // end
     endtask
 
 endclass : seq

--- a/src/sim/objects/seq.sv
+++ b/src/sim/objects/seq.sv
@@ -22,8 +22,8 @@ class seq extends uvm_sequence#(seq_item);
             assert(item.randomize()) else 
                 `uvm_fatal(get_type_name(), "Failed to randomize sequence item.")
 
-            `uvm_info(get_type_name(), $sformatf("Sending sequence item %0d: serial_in=%0b, we=%0b, out_dir=%0b, shift_dir=%0b", 
-                    i, item.serial_in, item.we,item.out_dir,item.shift_dir), UVM_LOW)
+            `uvm_info(get_type_name(), $sformatf("Sending sequence item %0d: serial_in=%0b, load=%0b, out_dir=%0b, shift_dir=%0b", 
+                    i, item.serial_in, item.load, item.out_dir,item.shift_dir), UVM_LOW)
 
             start_item(item);
             finish_item(item);

--- a/src/sim/objects/seq.sv
+++ b/src/sim/objects/seq.sv
@@ -22,8 +22,8 @@ class seq extends uvm_sequence#(seq_item);
             assert(item.randomize()) else 
                 `uvm_fatal(get_type_name(), "Failed to randomize sequence item.")
 
-            `uvm_info(get_type_name(), $sformatf("Sending sequence item %0d: serial_in=%0b, load=%0b, out_dir=%0b, shift_dir=%0b", 
-                    i, item.serial_in, item.load, item.out_dir,item.shift_dir), UVM_LOW)
+            `uvm_info(get_type_name(), $sformatf("Sending sequence item %0d: serial_in=%0b, load=%0b, out_dir=%0b", 
+                    i, item.serial_in, item.load, item.out_dir), UVM_LOW)
 
             start_item(item);
             finish_item(item);

--- a/src/sim/objects/seq.sv
+++ b/src/sim/objects/seq.sv
@@ -22,9 +22,8 @@ class seq extends uvm_sequence#(seq_item);
             assert(item.randomize()) else 
                 `uvm_fatal(get_type_name(), "Failed to randomize sequence item.")
 
-            `uvm_info(get_type_name(), 
-                $sformatf("Sending sequence item %0d: serial_in=%0b, we=%0b", 
-                    i, item.serial_in, item.we), UVM_LOW)
+            `uvm_info(get_type_name(), $sformatf("Sending sequence item %0d: serial_in=%0b, we=%0b, out_dir=%0b, shift_dir=%0b", 
+                    i, item.serial_in, item.we,item.out_dir,item.shift_dir), UVM_LOW)
 
             start_item(item);
             finish_item(item);

--- a/src/sim/objects/seq_fl.sv
+++ b/src/sim/objects/seq_fl.sv
@@ -1,0 +1,27 @@
+class seq_fl extends uvm_sequence#(seq_item);
+    `uvm_object_utils(seq_fl)
+
+    bit fl = 1'b1;
+
+    function new(string name = "seq_fl");
+        super.new(name);
+    endfunction
+
+    task body();
+        seq_item item;
+        item = seq_item::type_id::create("item");
+
+        if (!item.randomize()) 
+            `uvm_fatal(get_type_name(), "Failed to randomize sequence item.")
+
+        item.load = fl; // Force load
+        
+        `uvm_info(get_type_name(), $sformatf("Sending sequence item: serial_in=%0b, load=%0b, out_dir=%0b", 
+                item.serial_in, item.load, item.out_dir), UVM_LOW)
+
+        start_item(item);
+        finish_item(item);
+
+    endtask
+
+endclass : seq_fl

--- a/src/sim/objects/seq_item.sv
+++ b/src/sim/objects/seq_item.sv
@@ -2,6 +2,8 @@ class seq_item extends uvm_sequence_item;
 
     rand bit serial_in;
     rand bit we;
+    rand bit out_dir;
+    rand bit shift_dir;
 
     `uvm_object_utils(seq_item)
 

--- a/src/sim/objects/seq_item.sv
+++ b/src/sim/objects/seq_item.sv
@@ -3,7 +3,6 @@ class seq_item extends uvm_sequence_item;
     rand bit serial_in;
     rand bit load;
     rand bit out_dir;
-    rand bit shift_dir;
 
     `uvm_object_utils(seq_item)
 

--- a/src/sim/objects/seq_item.sv
+++ b/src/sim/objects/seq_item.sv
@@ -1,5 +1,6 @@
 class seq_item extends uvm_sequence_item;
 
+    logic arst_n;
     rand bit serial_in;
     rand bit load;
     rand bit out_dir;

--- a/src/sim/objects/seq_item.sv
+++ b/src/sim/objects/seq_item.sv
@@ -1,7 +1,7 @@
 class seq_item extends uvm_sequence_item;
 
     rand bit serial_in;
-    rand bit we;
+    rand bit load;
     rand bit out_dir;
     rand bit shift_dir;
 

--- a/src/sim/tb_top.sv
+++ b/src/sim/tb_top.sv
@@ -15,19 +15,22 @@ module tb_top;
     logic arst_n;
     logic serial_in;
     logic we;
+    logic out_dir;
+    logic shift_dir;
     logic [DATA_WIDTH-1:0] parallel_out;   
 
     ctrl_intf ctrl_if();
     data_intf #(DATA_WIDTH) data_if(.clk(clk), .arst_n(arst_n));
 
     sipo_reg #(
-        .DATA_WIDTH(DATA_WIDTH),
-        .SHIFT_LEFT(SHIFT_LEFT)
+        .DATA_WIDTH(DATA_WIDTH)
     ) dut (
         .clk(clk),
         .arst_n(arst_n),
         .serial_in(serial_in),
         .we(we),
+        .out_dir(out_dir),
+        .shift_dir(shift_dir),
         .parallel_out(parallel_out)
     );
 
@@ -35,6 +38,8 @@ module tb_top;
     assign arst_n = ctrl_if.arst_n;
     assign serial_in = data_if.serial_in;
     assign we = data_if.we;
+    assign out_dir = data_if.out_dir;
+    assign shift_dir = data_if.shift_dir;
     assign data_if.parallel_out = parallel_out;
 
     initial begin

--- a/src/sim/tb_top.sv
+++ b/src/sim/tb_top.sv
@@ -4,19 +4,16 @@ import uvm_pkg::*;
 
 module tb_top;
 
-    initial $display("##--------------TEST STARTED-------------_##");
+    initial $display("##--------------TEST STARTED--------------##");
     final $display("##--------------TEST ENDED--------------##");
 
     localparam int DATA_WIDTH = 32;
-    localparam int SEQ_LENGTH = 32;
-    localparam int SHIFT_LEFT = 1;
 
     logic clk;
     logic arst_n;
     logic serial_in;
     logic load;
     logic out_dir;
-    logic shift_dir;
     logic [DATA_WIDTH-1:0] parallel_out;   
 
     ctrl_intf ctrl_if();
@@ -30,7 +27,6 @@ module tb_top;
         .serial_in(serial_in),
         .load(load),
         .out_dir(out_dir),
-        .shift_dir(shift_dir),
         .parallel_out(parallel_out)
     );
 
@@ -39,7 +35,6 @@ module tb_top;
     assign serial_in = data_if.serial_in;
     assign load = data_if.load;
     assign out_dir = data_if.out_dir;
-    assign shift_dir = data_if.shift_dir;
     assign data_if.parallel_out = parallel_out;
 
     initial begin

--- a/src/sim/tb_top.sv
+++ b/src/sim/tb_top.sv
@@ -14,7 +14,7 @@ module tb_top;
     logic clk;
     logic arst_n;
     logic serial_in;
-    logic we;
+    logic load;
     logic out_dir;
     logic shift_dir;
     logic [DATA_WIDTH-1:0] parallel_out;   
@@ -28,7 +28,7 @@ module tb_top;
         .clk(clk),
         .arst_n(arst_n),
         .serial_in(serial_in),
-        .we(we),
+        .load(load),
         .out_dir(out_dir),
         .shift_dir(shift_dir),
         .parallel_out(parallel_out)
@@ -37,7 +37,7 @@ module tb_top;
     assign clk = ctrl_if.clk;
     assign arst_n = ctrl_if.arst_n;
     assign serial_in = data_if.serial_in;
-    assign we = data_if.we;
+    assign load = data_if.load;
     assign out_dir = data_if.out_dir;
     assign shift_dir = data_if.shift_dir;
     assign data_if.parallel_out = parallel_out;

--- a/src/sim/tests/test_1.sv
+++ b/src/sim/tests/test_1.sv
@@ -6,7 +6,7 @@ class test_1 extends base_test;
     function new(string name = "test_1", uvm_component parent = null);
         super.new(name, parent);
 
-        uvm_config_db#(int unsigned)::set(uvm_root::get(), "seq_length", "int", seq_length);
+        // uvm_config_db#(int unsigned)::set(uvm_root::get(), "seq_length", "int", seq_length);
     endfunction
 
     function void build_phase(uvm_phase phase);
@@ -14,16 +14,23 @@ class test_1 extends base_test;
     endfunction
 
     task run_phase(uvm_phase phase);
-        seq test_1_seq;
+        seq_fl test_seq_fl;
+
         super.run_phase(phase);
 
         phase.raise_objection(this);
         `uvm_info(get_type_name(), $sformatf("Starting test with sequence_length = %0d",seq_length), UVM_LOW)
 
-        test_1_seq = seq::type_id::create("test_1_seq");
+        for (int unsigned i = 0; i < seq_length; i++) begin
+            test_seq_fl = seq_fl::type_id::create("test_seq_fl");
+            test_seq_fl.start(envr.agt.sqr);
+        end
+        
+        test_seq_fl = seq_fl::type_id::create("test_seq_fl");
+        test_seq_fl.fl = 1'b0; // Set load to 0
+        repeat(3) test_seq_fl.start(envr.agt.sqr);
 
-        test_1_seq.start(envr.agt.sqr);
-
+        `uvm_info(get_type_name(), "Test completed.", UVM_LOW)
         phase.drop_objection(this);
     endtask
 endclass

--- a/src/sim/tests/test_1.sv
+++ b/src/sim/tests/test_1.sv
@@ -5,12 +5,12 @@ class test_1 extends base_test;
 
     function new(string name = "test_1", uvm_component parent = null);
         super.new(name, parent);
+
+        uvm_config_db#(int unsigned)::set(uvm_root::get(), "seq_length", "int", seq_length);
     endfunction
 
     function void build_phase(uvm_phase phase);
         super.build_phase(phase);
-
-        uvm_config_db#(int unsigned)::set(uvm_root::get(), "seq_length", "int", seq_length);
     endfunction
 
     task run_phase(uvm_phase phase);


### PR DESCRIPTION
Added features to the DUT: `sipo_reg`
- Output can start from LSB or MSB controlled by logic out_dir signal
- LEFT or RIGHT shift is determined by another signal logic shift_dir, not by parameter