### PR TITLE
3 test method reconsider

### DIFF
--- a/filelist.f
+++ b/filelist.f
@@ -20,6 +20,7 @@ src/sim/tb_top.sv
 src/sim/objects/seq_item.sv
 src/sim/objects/rsp_item.sv
 src/sim/objects/seq.sv
+src/sim/objects/seq_fl.sv
 
 #------------------------------
 # Components

--- a/src/sim/components/monitor.sv
+++ b/src/sim/components/monitor.sv
@@ -33,14 +33,15 @@ class monitor extends uvm_monitor;
                 item = rsp_item::type_id::create("item");
 
                 @(posedge data_if.clk);
-                if (data_if.arst_n == 1'b0) begin
-                    `uvm_info(get_type_name(), "In reset, waiting for reset de-assertion", UVM_MEDIUM)
-                    @(posedge data_if.arst_n);  // Wait for reset to end
-                end
+                // if (data_if.arst_n == 1'b0) begin
+                //     `uvm_info(get_type_name(), "In reset, waiting for reset de-assertion", UVM_MEDIUM)
+                //     @(posedge data_if.arst_n);  // Wait for reset to end
+                // end
 
                 item.serial_in    = data_if.serial_in;
                 item.load         = data_if.load;
                 item.out_dir      = data_if.out_dir;
+                item.arst_n       = data_if.arst_n;
                 item.parallel_out = data_if.parallel_out;
 
                 `uvm_info(get_type_name(), $sformatf("Monitoring signals: serial_in=%0b, load=%0b, out_dir=%0b, parallel_out=%0h",

--- a/src/sim/components/scb.sv
+++ b/src/sim/components/scb.sv
@@ -29,10 +29,11 @@ class scb extends uvm_component;
 
     // Called when monitor writes a transaction
     function void write(rsp_item t);
-
         // Shift the golden model according to DUT behavior
-        if(t.load) begin
-             // When we is high, output_expected is zero            
+        if(~t.arst_n) begin
+            output_expected = '0;
+        end else if(t.load) begin
+            // When we is high, output_expected is zero            
             golden_shift_reg = {golden_shift_reg[DATA_WIDTH-2:0], t.serial_in};
             output_expected = '0;
         end else begin

--- a/src/sim/objects/seq.sv
+++ b/src/sim/objects/seq.sv
@@ -1,7 +1,7 @@
 class seq extends uvm_sequence#(seq_item);
     `uvm_object_utils(seq)
 
-    int unsigned seq_length = 32;
+    // int unsigned seq_length = 32;
 
     function new(string name = "seq");
         super.new(name);
@@ -9,25 +9,25 @@ class seq extends uvm_sequence#(seq_item);
 
     task body();
         
-        void'(uvm_config_db #(int unsigned)::get(uvm_root::get(), 
-            "seq_length", "int", seq_length));
+        // void'(uvm_config_db #(int unsigned)::get(uvm_root::get(), 
+        //     "seq_length", "int", seq_length));
 
-        `uvm_info(get_type_name(), 
-            $sformatf("Creating %0d number of sequences.", seq_length), UVM_LOW)
+        // `uvm_info(get_type_name(), 
+        //     $sformatf("Creating %0d number of sequences.", seq_length), UVM_LOW)
 
-        for (int unsigned i = 0; i < seq_length; i++) begin
+        // for (int unsigned i = 0; i < seq_length; i++) begin
             seq_item item;
             item = seq_item::type_id::create("item");
 
             assert(item.randomize()) else 
                 `uvm_fatal(get_type_name(), "Failed to randomize sequence item.")
-
-            `uvm_info(get_type_name(), $sformatf("Sending sequence item %0d: serial_in=%0b, load=%0b, out_dir=%0b", 
-                    i, item.serial_in, item.load, item.out_dir), UVM_LOW)
+            
+            `uvm_info(get_type_name(), $sformatf("Sending sequence item: serial_in=%0b, load=%0b, out_dir=%0b", 
+                    item.serial_in, item.load, item.out_dir), UVM_LOW)
 
             start_item(item);
             finish_item(item);
-        end
+        // end
     endtask
 
 endclass : seq

--- a/src/sim/objects/seq_fl.sv
+++ b/src/sim/objects/seq_fl.sv
@@ -1,0 +1,27 @@
+class seq_fl extends uvm_sequence#(seq_item);
+    `uvm_object_utils(seq_fl)
+
+    bit fl = 1'b1;
+
+    function new(string name = "seq_fl");
+        super.new(name);
+    endfunction
+
+    task body();
+        seq_item item;
+        item = seq_item::type_id::create("item");
+
+        if (!item.randomize()) 
+            `uvm_fatal(get_type_name(), "Failed to randomize sequence item.")
+
+        item.load = fl; // Force load
+        
+        `uvm_info(get_type_name(), $sformatf("Sending sequence item: serial_in=%0b, load=%0b, out_dir=%0b", 
+                item.serial_in, item.load, item.out_dir), UVM_LOW)
+
+        start_item(item);
+        finish_item(item);
+
+    endtask
+
+endclass : seq_fl

--- a/src/sim/objects/seq_item.sv
+++ b/src/sim/objects/seq_item.sv
@@ -1,5 +1,6 @@
 class seq_item extends uvm_sequence_item;
 
+    logic arst_n;
     rand bit serial_in;
     rand bit load;
     rand bit out_dir;

--- a/src/sim/tests/test_1.sv
+++ b/src/sim/tests/test_1.sv
@@ -6,7 +6,7 @@ class test_1 extends base_test;
     function new(string name = "test_1", uvm_component parent = null);
         super.new(name, parent);
 
-        uvm_config_db#(int unsigned)::set(uvm_root::get(), "seq_length", "int", seq_length);
+        // uvm_config_db#(int unsigned)::set(uvm_root::get(), "seq_length", "int", seq_length);
     endfunction
 
     function void build_phase(uvm_phase phase);
@@ -14,16 +14,23 @@ class test_1 extends base_test;
     endfunction
 
     task run_phase(uvm_phase phase);
-        seq test_1_seq;
+        seq_fl test_seq_fl;
+
         super.run_phase(phase);
 
         phase.raise_objection(this);
         `uvm_info(get_type_name(), $sformatf("Starting test with sequence_length = %0d",seq_length), UVM_LOW)
 
-        test_1_seq = seq::type_id::create("test_1_seq");
+        for (int unsigned i = 0; i < seq_length; i++) begin
+            test_seq_fl = seq_fl::type_id::create("test_seq_fl");
+            test_seq_fl.start(envr.agt.sqr);
+        end
+        
+        test_seq_fl = seq_fl::type_id::create("test_seq_fl");
+        test_seq_fl.fl = 1'b0; // Set load to 0
+        repeat(3) test_seq_fl.start(envr.agt.sqr);
 
-        test_1_seq.start(envr.agt.sqr);
-
+        `uvm_info(get_type_name(), "Test completed.", UVM_LOW)
         phase.drop_objection(this);
     endtask
 endclass


### PR DESCRIPTION
Issue: https://github.com/mdjannatulnayem/uvm-tb-sipo-reg/issues/3

Fix:
- Monitor doesn't sample while reset ----> Now it does 
- The scoreboard should expect parallel_out = 0 while reset ----> Done
- The scoreboard on getting a load, waits M clock cycles to get the reg populated --> Achieved by driving sequences
- Drive N number of sequence from the test class instead ----> Done